### PR TITLE
Destroy also awareness on destroy

### DIFF
--- a/src/client/provider.ts
+++ b/src/client/provider.ts
@@ -323,6 +323,7 @@ export class SocketIOProvider extends Observable<string> {
     if (typeof window !== 'undefined') window.removeEventListener('beforeunload', this.beforeUnloadHandler)
     else if (typeof process !== 'undefined') process.off('exit', this.beforeUnloadHandler)
     this.awareness.off('update', this.awarenessUpdate)
+    this.awareness.destroy();
     this.doc.off('update', this.onUpdateDoc)
     super.destroy()
   }


### PR DESCRIPTION
When calling destroy, awareness is kept, and it holds handlers, that could cause memory leaks