### PR TITLE
Add option to debounce updates and debounce awareness updates

### DIFF
--- a/src/client/provider.ts
+++ b/src/client/provider.ts
@@ -233,6 +233,12 @@ export class SocketIOProvider extends Observable<string> {
     this.onPending = onPending
     this.pendingUpdates = []
 
+    this.initSyncListeners()
+
+    this.initAwarenessListeners()
+
+    this.initSystemListeners()
+
     this.doc.on('update', this.onUpdateDoc)
 
     this.socket.on('connect', () => this.onSocketConnection(resyncInterval))
@@ -240,12 +246,6 @@ export class SocketIOProvider extends Observable<string> {
     this.socket.on('disconnect', (event) => this.onSocketDisconnection(event))
 
     this.socket.on('connect_error', (error) => this.onSocketConnectionError(error))
-
-    this.initSyncListeners()
-
-    this.initAwarenessListeners()
-
-    this.initSystemListeners()
 
     awareness.on('update', this.awarenessUpdate)
 

--- a/src/client/provider.ts
+++ b/src/client/provider.ts
@@ -95,6 +95,12 @@ export class SocketIOProvider extends Observable<string> {
    */
   private updateTimer?: ReturnType<typeof setTimeout>
   /**
+   * The timer used to debounce document awareness updates
+   * @type {ReturnType<typeof setTimeout>}
+   * @private
+   */
+  private updateAwarenessTimer?: ReturnType<typeof setTimeout>
+  /**
    * Notify pending state when debouncing
    * @type {((pending: boolean) => void) | undefined}
    */
@@ -462,12 +468,12 @@ export class SocketIOProvider extends Observable<string> {
     if (this.debounceAwarenessTime === undefined) {
       this.awarenessUpdateInner(awarenessChange, origin)
     }
-    if (this.updateTimer !== undefined) {
-      clearTimeout(this.updateTimer)
+    if (this.updateAwarenessTimer !== undefined) {
+      clearTimeout(this.updateAwarenessTimer)
     }
-    this.updateTimer = setTimeout(() => {
+    this.updateAwarenessTimer = setTimeout(() => {
       this.awarenessUpdateInner(awarenessChange, origin)
-      this.updateTimer = undefined
+      this.updateAwarenessTimer = undefined
     }, this.debounceAwarenessTime)
   }
 

--- a/src/client/provider.ts
+++ b/src/client/provider.ts
@@ -396,7 +396,7 @@ export class SocketIOProvider extends Observable<string> {
     if (origin === this) {
       return
     }
-    if (this.debounceTime !== undefined) {
+    if (this.debounceTime === undefined) {
       this.onUpdateDocInner(update, origin)
     }
     if (this.updateTimer !== undefined) {

--- a/src/server/document.ts
+++ b/src/server/document.ts
@@ -36,11 +36,17 @@ export class Document extends Y.Doc {
    */
   public name: string
   /**
-   * The socket connection
+   * The namespace connection
    * @type {Namespace}
    * @private
    */
   private readonly namespace: Namespace
+  /**
+   * Indicator as to whether to send document updates only to local WebSockets
+   * @type {boolean}
+   * @private
+   */
+  private readonly localOnly?: boolean
   /**
    * The document awareness
    * @type {Awareness}
@@ -58,12 +64,14 @@ export class Document extends Y.Doc {
    * @constructor
    * @param {string} name Name for the document
    * @param {Namespace} namespace The namespace connection
+   * @param {boolean} localOnly Indicator as to whether to send document updates only to local WebSockets
    * @param {Callbacks} callbacks The document callbacks
    */
-  constructor (name: string, namespace: Namespace, callbacks?: Callbacks) {
+  constructor (name: string, namespace: Namespace, localOnly?: boolean, callbacks?: Callbacks) {
     super({ gc: gcEnabled })
     this.name = name
     this.namespace = namespace
+    this.localOnly = localOnly
     this.awareness = new AwarenessProtocol.Awareness(this)
     this.awareness.setLocalState(null)
     this.callbacks = callbacks
@@ -87,7 +95,11 @@ export class Document extends Y.Doc {
         console.warn(error)
       }
     }
-    this.namespace.emit('sync-update', update)
+    if (this.localOnly !== undefined && this.localOnly) {
+      this.namespace.local.emit('sync-update', update)
+    } else {
+      this.namespace.emit('sync-update', update)
+    }
   }
 
   /**

--- a/src/server/y-socket-io.ts
+++ b/src/server/y-socket-io.ts
@@ -46,7 +46,7 @@ export interface YSocketIOConfiguration {
    *  It can be a promise and if it returns true, the connection is allowed; otherwise, if it returns false, the connection is rejected.
    * @param handshake Provided from the handshake attribute of the socket io
    */
-  authenticate?: (handshake: { [key: string]: any }) => Promise<boolean> | boolean
+  authenticate?: (handshake: Handshake) => Promise<boolean> | boolean
 }
 
 /**

--- a/src/server/y-socket-io.ts
+++ b/src/server/y-socket-io.ts
@@ -4,6 +4,9 @@ import * as AwarenessProtocol from 'y-protocols/awareness'
 import { LeveldbPersistence } from 'y-leveldb'
 import { Document } from './document'
 import { Observable } from 'lib0/observable'
+import { Handshake } from 'socket.io/dist/socket'
+
+const DEFAULT_TIMEOUT_FOR_ACK = 10_000
 
 /**
  * Level db persistence object
@@ -25,6 +28,14 @@ export interface YSocketIOConfiguration {
    * Enable/Disable garbage collection (default: gc=true)
    */
   gcEnabled?: boolean
+  /**
+   * Enable/Disable sending messages only to local WebSockets
+   */
+  localOnly?: boolean
+  /**
+   * Set timeout time for acknowledgements
+   */
+  timeoutForAck?: number
   /**
    * The directory path where the persistent Level database will be stored
    */
@@ -104,7 +115,7 @@ export class YSocketIO extends Observable<string> {
     this.nsp.on('connection', async (socket) => {
       const namespace = socket.nsp.name.replace(/\/yjs\|/, '')
 
-      const doc = await this.initDocument(namespace, socket.nsp, this.configuration?.gcEnabled)
+      const doc = await this.initDocument(namespace, socket.nsp, this.configuration?.localOnly, this.configuration?.gcEnabled)
 
       this.initSyncListeners(socket, doc)
       this.initAwarenessListeners(socket, doc)
@@ -138,8 +149,8 @@ export class YSocketIO extends Observable<string> {
    * @param {boolean} gc Enable/Disable garbage collection (default: gc=true)
    * @returns {Promise<Document>} The document
    */
-  private async initDocument (name: string, namespace: Namespace, gc: boolean = true): Promise<Document> {
-    const doc = this._documents.get(name) ?? (new Document(name, namespace, {
+  private async initDocument (name: string, namespace: Namespace, localOnly?: boolean, gc: boolean = true): Promise<Document> {
+    const doc = this._documents.get(name) ?? (new Document(name, namespace, localOnly, {
       onUpdate: (doc, update) => this.emit('document-update', [doc, update]),
       onChangeAwareness: (doc, update) => this.emit('awareness-update', [doc, update]),
       onDestroy: async (doc) => {
@@ -256,7 +267,13 @@ export class YSocketIO extends Observable<string> {
    * @param {Document} doc The document
    */
   private readonly startSynchronization = (socket: Socket, doc: Document): void => {
-    socket.emit('sync-step-1', Y.encodeStateVector(doc), (update: Uint8Array) => {
+    socket.timeout(
+      this.configuration?.timeoutForAck ?? DEFAULT_TIMEOUT_FOR_ACK
+    ).emit('sync-step-1', Y.encodeStateVector(doc), (error: Error | undefined | null, update: Uint8Array) => {
+      if (error !== undefined && error !== null) {
+        console.error('An error occurred during sync-step-1', error)
+        return
+      }
       Y.applyUpdate(doc, new Uint8Array(update), this)
     })
     socket.emit('awareness-update', AwarenessProtocol.encodeAwarenessUpdate(doc.awareness, Array.from(doc.awareness.getStates().keys())))


### PR DESCRIPTION
- Allow users to debounce their updates to the server (the client accumulates the updates and merges them before syncing at the interval), merging the Y.js updates into a single update over that given period, also to be able to notify users that their updates were not synced to the server.
- Allow users to debounce their awareness updates to the server (sending an update once every given time to the server)

Notes on debouncing:
  - The deboucing allow users to specify the time over which to delay, i.e. the debounce time, but also a max wait to ensure that updates on content changes and awareness are sent at least once every `n` time
- I provide an `onPending` function which is used to indicate that there is local debounced data which has not yet been sent (i.e. changes which have not yet "been saved")
- Added a `localOnly` flag to use `.local` on Socket.IO to only broadcast to local sockets, even when using an adapter for document updates, since those updates would need to be applied via some other mechanism anyway to synchronize the content between the servers (since the y.js document is stateful, and not synchronizing the server instances causes them to essentially fail)
- Added a `timeoutForAck` argument to specify the timeout for the first "sync-step-1" since it can fail (i.e. not receive an acknowledgement) and so I added a log for such a case
- I fixed the type annotation for the handshake for the `authenticate` argument